### PR TITLE
Pin hf hub version to avoid problem with nemo import

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-huggingface_hub>=0.20.3
+huggingface_hub==0.23.2
 numba
 numpy>=1.22
 onnx>=1.7.0


### PR DESCRIPTION
# What does this PR do ?
Fix https://github.com/AI4Bharat/NeMo/issues/11

# Changelog 
- Pins huggingface-hub==0.23.2 in `requirements/requirements.txt`

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
https://github.com/NVIDIA/NeMo/issues/9793