### PR TITLE
Fix NumPy 2.x compatibility in ASR preprocessing

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/feature_loader.py
+++ b/nemo/collections/asr/parts/preprocessing/feature_loader.py
@@ -50,10 +50,10 @@ class ExternalFeatureLoader(object):
         Integers will be scaled to [-1, 1] in float32.
         """
         float32_samples = samples.astype('float32')
-        if samples.dtype in np.sctypes['int']:
+        if np.issubdtype(samples.dtype, np.signedinteger):
             bits = np.iinfo(samples.dtype).bits
             float32_samples *= 1.0 / 2 ** (bits - 1)
-        elif samples.dtype in np.sctypes['float']:
+        elif np.issubdtype(samples.dtype, np.floating):
             pass
         else:
             raise TypeError("Unsupported sample type: %s." % samples.dtype)

--- a/nemo/collections/asr/parts/preprocessing/segment.py
+++ b/nemo/collections/asr/parts/preprocessing/segment.py
@@ -165,10 +165,10 @@ class AudioSegment(object):
         Integers will be scaled to [-1, 1] in float32.
         """
         float32_samples = samples.astype('float32')
-        if samples.dtype in np.sctypes['int']:
+        if np.issubdtype(samples.dtype, np.signedinteger):
             bits = np.iinfo(samples.dtype).bits
             float32_samples *= 1.0 / 2 ** (bits - 1)
-        elif samples.dtype in np.sctypes['float']:
+        elif np.issubdtype(samples.dtype, np.floating):
             pass
         else:
             raise TypeError("Unsupported sample type: %s." % samples.dtype)

--- a/tests/collections/asr/test_preprocessing_segment.py
+++ b/tests/collections/asr/test_preprocessing_segment.py
@@ -201,3 +201,27 @@ class TestAudioSegment:
             _ = perturber.perturb(audio)
 
             assert len(audio._samples) == ori_audio_len + 2 * dur * self.sample_rate
+
+    def test_convert_samples_to_float32_signed_integer(self):
+        samples = np.array([0, 32767, -32768], dtype=np.int16)
+
+        result = AudioSegment._convert_samples_to_float32(samples)
+
+        assert result.dtype == np.float32
+        assert result[0] == 0.0
+        assert result[1] == pytest.approx(32767 / 32768)
+        assert result[2] == pytest.approx(-1.0)
+
+    def test_convert_samples_to_float32_float(self):
+        samples = np.array([0.0, 0.5, -0.5], dtype=np.float32)
+
+        result = AudioSegment._convert_samples_to_float32(samples)
+
+        assert result.dtype == np.float32
+        np.testing.assert_allclose(result, samples)
+
+    def test_convert_samples_to_float32_unsigned_integer(self):
+        samples = np.array([0, 127, 255], dtype=np.uint8)
+
+        with pytest.raises(TypeError, match="Unsupported sample type"):
+            AudioSegment._convert_samples_to_float32(samples)


### PR DESCRIPTION
# What does this PR do?

Fixes NumPy 2.x compatibility in the ASR preprocessing audio sample conversion logic.

**Collection:** ASR

# Changelog

- Replace the removed `np.sctypes` API with `np.issubdtype`.
- Preserve signed-integer and floating-point sample handling.
- Preserve rejection of unsupported unsigned integer sample types.
- Add regression tests for signed integer, floating-point, and unsigned integer inputs.

# Usage

No usage changes. This is an internal compatibility fix.

# Before your PR is "Ready for review"

- [x] I have read and followed the Contributor guidelines
- [x] Did you write any necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install?
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Who can review?

Anyone familiar with the ASR preprocessing pipeline and NumPy compatibility can review this PR.

# Additional Information

- Related to the NumPy 2.x `np.sctypes` removal.
- `git diff --check` passes.
- Targeted pytest collection is currently blocked by an unrelated `NeptuneLogger` import incompatibility in the current `nemo-v2` environment.
- The changed sample-conversion logic was independently validated with NumPy 2.5.2.